### PR TITLE
Fix off-by-one bug in four_inp helper

### DIFF
--- a/compiler/q_engine.h
+++ b/compiler/q_engine.h
@@ -120,7 +120,7 @@ private:
         for(int i = 0; i < n_bit_src3; i++)
             src3[i] = program_memory[(offset)+n_bit_src3-i-1];
         offset += n_bit_src3;
-        for(int i = 0; i < n_bit_src3; i++)
+        for(int i = 0; i < n_bit_src4; i++)
             src4[i] = program_memory[(offset)+n_bit_src4-i-1];
 
         tuple<T, T, T, T> t = {src1.to_ullong(),


### PR DESCRIPTION
## Summary
- correct the loop limit in `four_inp` for `q_engine`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `g++ compiler/run_engine.cpp -o compiler/run_engine.exe` *(fails: `uint64_t` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6843200963dc832db0680463fb0cc8d4